### PR TITLE
support adaptor signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ base16ct = { version = "0.2.0", default-features = false, features = ["alloc"] }
 k256 = { version = "0.13.1", default-features = false, optional = true }
 once_cell = { version = "1.18.0", default-features = false }
 rand = { version = "0.8.5", optional = true, default-features = false, features = ["std_rng"] }
-secp = { version = "0.1.0", default-features = false }
+secp = { version = "0.2.0", default-features = false }
 secp256k1 = { version = "0.28.0", optional = true, default-features = false }
 serde = { version = "1.0.188", default-features = false, optional = true }
 serdect = { version = "0.2.0", default-features = false, optional = true, features = ["alloc"] }
@@ -28,7 +28,7 @@ serde_json = "1.0.107"
 csv = "1.3.0"
 serdect = "0.2.0"
 rand = "0.8.5"
-secp = { version = "0.1.0", default-features = false, features = ["serde", "rand", "secp256k1-invert"]  }
+secp = { version = "0.2.0", default-features = false, features = ["serde", "rand", "secp256k1-invert"]  }
 
 [features]
 default = ["secp256k1"]

--- a/doc/adaptor_signatures.md
+++ b/doc/adaptor_signatures.md
@@ -1,0 +1,246 @@
+This module exports [adaptor signature](https://bitcoinops.org/en/topics/adaptor-signatures/) implementations of BIP340 signing and MuSig signing.
+
+Adaptor signatures allow signers to create Schnorr signatures which can be verified, but do not pass BIP340 verification logic unless a specific secret scalar is added to the signature.
+
+[Further reading](https://conduition.io/scriptless/adaptorsigs/).
+
+## MuSig Example
+
+Here we demonstrate a group of MuSig2 signers adaptor-signing the same message. The final signature which the group constructs is an [`AdaptorSignature`][crate::AdaptorSignature], which they cannot use until it has been decrypted (AKA 'adapted') by the correct adaptor secret (a scalar).
+
+```rust
+use secp::{MaybeScalar, Point, Scalar};
+use musig2::{AdaptorSignature, KeyAggContext, PartialSignature, PubNonce};
+
+let seckeys = [
+    Scalar::from_slice(&[0x11; 32]).unwrap(),
+    Scalar::from_slice(&[0x22; 32]).unwrap(),
+    Scalar::from_slice(&[0x33; 32]).unwrap(),
+];
+
+let pubkeys = [
+    seckeys[0].base_point_mul(),
+    seckeys[1].base_point_mul(),
+    seckeys[2].base_point_mul(),
+];
+
+let key_agg_ctx = KeyAggContext::new(pubkeys).unwrap();
+let aggregated_pubkey: Point = key_agg_ctx.aggregated_pubkey();
+
+let message = "danger, will robinson!";
+
+let adaptor_secret = Scalar::random(&mut rand::thread_rng());
+let adaptor_point = adaptor_secret.base_point_mul();
+
+// Using the functional API.
+{
+    use musig2::{AggNonce, SecNonce};
+
+    let secnonces = [
+        SecNonce::build([0x11; 32]).build(),
+        SecNonce::build([0x22; 32]).build(),
+        SecNonce::build([0x33; 32]).build(),
+    ];
+
+    let pubnonces = [
+        secnonces[0].public_nonce(),
+        secnonces[1].public_nonce(),
+        secnonces[2].public_nonce(),
+    ];
+
+    let aggnonce = AggNonce::sum(&pubnonces);
+
+    let partial_signatures: Vec<PartialSignature> = seckeys
+        .into_iter()
+        .zip(secnonces)
+        .map(|(seckey, secnonce)| {
+            musig2::adaptor::sign_partial(
+                &key_agg_ctx,
+                seckey,
+                secnonce,
+                &aggnonce,
+                adaptor_point,
+                &message,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .expect("failed to create partial adaptor signatures");
+
+    let adaptor_signature: AdaptorSignature = musig2::adaptor::aggregate_partial_signatures(
+        &key_agg_ctx,
+        &aggnonce,
+        adaptor_point,
+        partial_signatures.iter().copied(),
+        &message,
+    )
+    .expect("failed to aggregate partial adaptor signatures");
+
+    // Verify the adaptor signature is valid for the given adaptor point and pubkey.
+    musig2::adaptor::verify_single(
+        aggregated_pubkey,
+        &adaptor_signature,
+        &message,
+        adaptor_point,
+    )
+    .expect("invalid aggregated adaptor signature");
+
+    // Decrypt the signature with the adaptor secret.
+    let valid_signature = adaptor_signature.adapt(adaptor_secret).unwrap();
+
+    musig2::verify_single(
+        aggregated_pubkey,
+        valid_signature,
+        &message,
+    )
+    .expect("invalid decrypted adaptor signature");
+
+    // The decrypted signature and the adaptor signature allow an
+    // observer to deduce the adaptor secret.
+    let revealed: MaybeScalar = adaptor_signature
+        .reveal_secret(&valid_signature)
+        .expect("should compute adaptor secret from decrypted signature");
+
+    assert_eq!(revealed, MaybeScalar::Valid(adaptor_secret));
+}
+
+// Using the state-machine API
+{
+    use musig2::{FirstRound, SecNonceSpices, SecondRound};
+
+    let spiced = |i| SecNonceSpices::new()
+        .with_seckey(seckeys[i])
+        .with_message(&message);
+
+    let mut first_rounds = vec![
+        FirstRound::new(key_agg_ctx.clone(), [0x11; 32], 0, spiced(0)).unwrap(),
+        FirstRound::new(key_agg_ctx.clone(), [0x22; 32], 1, spiced(1)).unwrap(),
+        FirstRound::new(key_agg_ctx.clone(), [0x33; 32], 2, spiced(2)).unwrap(),
+    ];
+
+    let public_nonces = [
+        first_rounds[0].our_public_nonce(),
+        first_rounds[1].our_public_nonce(),
+        first_rounds[2].our_public_nonce(),
+    ];
+
+    for round in first_rounds.iter_mut() {
+        round.receive_nonce(0, public_nonces[0].clone()).unwrap();
+        round.receive_nonce(1, public_nonces[1].clone()).unwrap();
+        round.receive_nonce(2, public_nonces[2].clone()).unwrap();
+    }
+
+    // The `finalize_adaptor` method must be used instead of `finalize`, on
+    // both first and second rounds.
+    let mut second_rounds: Vec<SecondRound<&str>> = first_rounds
+        .into_iter()
+        .enumerate()
+        .map(|(i, round)| round.finalize_adaptor(seckeys[i], adaptor_point, message).unwrap())
+        .collect();
+
+    let partial_sigs: [PartialSignature; 3] = [
+        second_rounds[0].our_signature(),
+        second_rounds[1].our_signature(),
+        second_rounds[2].our_signature(),
+    ];
+
+    for round in second_rounds.iter_mut() {
+        round.receive_signature(0, partial_sigs[0]).unwrap();
+        round.receive_signature(1, partial_sigs[1]).unwrap();
+        round.receive_signature(2, partial_sigs[2]).unwrap();
+    }
+
+    for second_round in second_rounds.into_iter() {
+        let adaptor_signature = second_round.finalize_adaptor::<AdaptorSignature>().unwrap();
+
+        // Verify the adaptor signature is valid for the given adaptor point and pubkey.
+        musig2::adaptor::verify_single(
+            aggregated_pubkey,
+            &adaptor_signature,
+            &message,
+            adaptor_point,
+        )
+        .expect("invalid aggregated adaptor signature");
+
+        // Decrypt the signature with the adaptor secret.
+        let valid_signature = adaptor_signature.adapt(adaptor_secret).unwrap();
+        musig2::verify_single(
+            aggregated_pubkey,
+            valid_signature,
+            &message,
+        )
+        .expect("invalid decrypted adaptor signature");
+
+        // The decrypted signature and the adaptor signature allow an
+        // observer to deduce the adaptor secret.
+        let revealed: MaybeScalar = adaptor_signature
+            .reveal_secret(&valid_signature)
+            .expect("should compute adaptor secret from decrypted signature");
+
+        assert_eq!(revealed, MaybeScalar::Valid(adaptor_secret));
+    }
+}
+```
+
+## Single Signer Example
+
+We also export single-signer adaptor signing logic.
+
+```rust
+use secp::{MaybeScalar, Scalar};
+
+let seckey = Scalar::random(&mut rand::rngs::OsRng);
+let message = "hello world!";
+
+// Create an adaptor signature, encrypted under a specific adaptor point.
+let adaptor_secret = Scalar::random(&mut rand::rngs::OsRng);
+let adaptor_point = adaptor_secret.base_point_mul();
+let aux_rand = [0xAA; 32]; // Should use an actual RNG.
+let adaptor_signature =
+    musig2::adaptor::sign_solo(seckey, message, aux_rand, adaptor_point);
+
+// Verify the adaptor signature is valid for the given adaptor point and pubkey.
+let pubkey = seckey.base_point_mul();
+musig2::adaptor::verify_single(pubkey, &adaptor_signature, message, adaptor_point)
+    .expect("valid adaptor signature should verify");
+
+// Decrypt the signature with the adaptor secret.
+let valid_sig: musig2::LiftedSignature = adaptor_signature
+    .adapt(adaptor_secret)
+    .expect("invalid adaptor secret");
+
+musig2::verify_single(pubkey, valid_sig, message)
+    .expect("decrypted adaptor signature is valid");
+
+// The decrypted signature and the adaptor signature allow an
+// observer to deduce the adaptor secret.
+let revealed: MaybeScalar = adaptor_signature.reveal_secret(&valid_sig)
+    .expect("decrypted sig should reveal adaptor secret");
+assert_eq!(revealed, MaybeScalar::Valid(adaptor_secret));
+```
+
+## Encrypting Signatures
+
+The above examples create signatures by committing to an adaptor point as part of the signing process. This is the way most adaptor signatures are created.
+
+However, you can also encrypt existing signatures (including existing adaptor signatures) by tweaking them with an adaptor secret. This requires knowing the adaptor secret though, so you can't do this if you only know the public adaptor point.
+
+```rust
+let signature = musig2::LiftedSignature::from_hex(
+    "e565f19755422162cf7dc69ed8a4f4a27d81363d024a3de355644003da33ed2f\
+     0cdd95945c6d28841192867842c104391b9cc31f25706ee302a96204a1d43eb7"
+)
+.unwrap();
+
+let adaptor_secret_1 = secp::Scalar::from_slice(&[0x55; 32]).unwrap();
+let mut adaptor_signature: musig2::AdaptorSignature = signature.encrypt(adaptor_secret_1);
+
+// We can re-encrypt the same adaptor signature twice, so that it is locked behind
+// two different points. Both secrets must be learned to compute the valid signature.
+let adaptor_secret_2 = secp::Scalar::from_slice(&[0x66; 32]).unwrap();
+adaptor_signature = adaptor_signature.encrypt(adaptor_secret_2);
+
+let decrypted: [u8; 64] = adaptor_signature
+    .adapt(adaptor_secret_1 + adaptor_secret_2)
+    .expect("valid decrypted adaptor signature");
+assert_eq!(decrypted, signature.serialize());
+```

--- a/src/bip340.rs
+++ b/src/bip340.rs
@@ -1,36 +1,39 @@
 use crate::errors::VerifyError;
 use crate::{
-    compute_challenge_hash_tweak, tagged_hashes, xor_bytes, CompactSignature, LiftedSignature,
-    NonceSeed,
+    compute_challenge_hash_tweak, tagged_hashes, xor_bytes, AdaptorSignature, CompactSignature,
+    LiftedSignature, NonceSeed,
 };
 
-use secp::{MaybeScalar, Point, Scalar, G};
+use secp::{MaybePoint, MaybeScalar, Point, Scalar, G};
 
-#[cfg(feature = "rand")]
-use secp::MaybePoint;
-
-#[cfg(feature = "rand")]
+#[cfg(any(test, feature = "rand"))]
 use rand::SeedableRng as _;
 
 use sha2::Digest as _;
 use subtle::ConstantTimeEq as _;
 
 /// Create a [BIP340-compatible](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
-/// Schnorr signature on the given message with a single private key.
+/// Schnorr adaptor signature on the given message with a single private key.
+///
+/// The resulting signature is verifiably encrypted under the given `adaptor_point`,
+/// such that it can only be considered valid under BIP340 if it is then
+/// _adapted_ using the discrete log of `adaptor_point`. See
+/// [`AdaptorSignature::adapt`] to decrypt it once you know the adaptor secret.
+///
+/// You can also compute the adaptor secret from the final decrypted signature,
+/// if you can find it.
 ///
 /// This is provided in case MuSig implementations may wish to make use of
 /// signatures to non-interactively prove the origin of a message. For example,
 /// if all messages between co-signers are signed, then peers can assign blame
 /// to any dishonest signers by sharing a copy of their dishonest message, which
 /// will bear their signature.
-pub fn sign_solo<T>(
+pub fn sign_solo_adaptor(
     seckey: impl Into<Scalar>,
     message: impl AsRef<[u8]>,
     nonce_seed: impl Into<NonceSeed>,
-) -> T
-where
-    T: From<LiftedSignature>,
-{
+    adaptor_point: impl Into<MaybePoint>,
+) -> AdaptorSignature {
     let seckey: Scalar = seckey.into();
     let nonce_seed: NonceSeed = nonce_seed.into();
 
@@ -60,15 +63,83 @@ where
         MaybeScalar::Valid(k) => k,
     };
 
-    let R = prenonce * G;
-    let k = prenonce.negate_if(R.parity());
-    let nonce_x_bytes = R.serialize_xonly();
+    let R = prenonce * G; // encrypted nonce
+    let adapted_nonce = R + adaptor_point.into();
 
+    // If the adapted nonce is odd-parity, we must negate our nonce and
+    // later also negate the adaptor secret at decryption time.
+    let k = prenonce.negate_if(adapted_nonce.parity());
+
+    let nonce_x_bytes = adapted_nonce.serialize_xonly();
     let e: MaybeScalar = compute_challenge_hash_tweak(&nonce_x_bytes, &pubkey, message);
 
     let s = k + e * d;
 
-    T::from(LiftedSignature::new(R, s))
+    AdaptorSignature::new(R, s)
+}
+
+/// Create a [BIP340-compatible](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
+/// Schnorr signature on the given message with a single private key.
+///
+/// This is provided in case MuSig implementations may wish to make use of
+/// signatures to non-interactively prove the origin of a message. For example,
+/// if all messages between co-signers are signed, then peers can assign blame
+/// to any dishonest signers by sharing a copy of their dishonest message, which
+/// will bear their signature.
+///
+/// This function is effectively the same as [`sign_solo_adaptor`] but passing
+/// [`MaybePoint::Infinity`] as the adaptor point.
+pub fn sign_solo<T>(
+    seckey: impl Into<Scalar>,
+    message: impl AsRef<[u8]>,
+    nonce_seed: impl Into<NonceSeed>,
+) -> T
+where
+    T: From<LiftedSignature>,
+{
+    sign_solo_adaptor(seckey, message, nonce_seed, MaybePoint::Infinity)
+        .adapt(MaybeScalar::Zero)
+        .map(T::from)
+        .expect("signing with empty adaptor should never result in an adaptor failure")
+}
+
+/// Verifies a [BIP340-compatible](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
+/// Schnorr adaptor signature, which could be aggregated or from a single-signer.
+///
+/// The signature will verify only if it is encrypted under the given adaptor point.
+///
+/// The `signature` argument is parsed as a [`LiftedSignature`]. You may pass any
+/// type which converts fallibly to a [`LiftedSignature`], including `&[u8]`, `[u8; 64]`,
+/// [`CompactSignature`], and so on.
+///
+/// Returns an error if the adaptor signature is invalid, which includes
+/// if the signature has been decrypted and is a fully valid signature.
+pub fn verify_single_adaptor(
+    pubkey: impl Into<Point>,
+    adaptor_signature: &AdaptorSignature,
+    message: impl AsRef<[u8]>,
+    adaptor_point: impl Into<MaybePoint>,
+) -> Result<(), VerifyError> {
+    use VerifyError::BadSignature;
+
+    let pubkey: Point = pubkey.into().to_even_y(); // lift_x(x(P))
+
+    let &AdaptorSignature { R, s } = adaptor_signature;
+
+    let adapted_nonce = R + adaptor_point.into();
+    let nonce_x_bytes = adapted_nonce.serialize_xonly();
+    let e: MaybeScalar = compute_challenge_hash_tweak(&nonce_x_bytes, &pubkey, message);
+
+    // If the adapted nonce is odd-parity, the signer should have negated their nonce
+    // when signing.
+    let effective_nonce = if adapted_nonce.has_even_y() { R } else { -R };
+
+    // sG = R + eD
+    if s * G != effective_nonce + e * pubkey {
+        return Err(BadSignature);
+    }
+
+    Ok(())
 }
 
 /// Verifies a [BIP340-compatible](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
@@ -76,7 +147,7 @@ where
 ///
 /// The `signature` argument is parsed as a [`CompactSignature`]. You may pass any
 /// type which converts fallibly to a [`CompactSignature`], including `&[u8]`, `[u8; 64]`,
-/// `LiftedSignature`, and so on.
+/// [`LiftedSignature`], and so on.
 ///
 /// Returns an error if the signature is invalid.
 pub fn verify_single(
@@ -132,8 +203,8 @@ pub fn verify_single(
 /// This requires the `rand` library for access to a seedable CSPRNG.
 /// The RNG is seeded with all the pubkeys, messages, and signatures
 /// rather than being truly random.
-#[cfg(feature = "rand")]
-pub fn verify_batch<P, M, T>(
+#[cfg(any(test, feature = "rand"))]
+pub fn verify_batch<P, T>(
     pubkeys: &[P],
     messages: &[impl AsRef<[u8]>],
     raw_signatures: &[T],
@@ -282,6 +353,33 @@ mod tests {
                     record.index,
                     &record.comment
                 );
+
+                // Test adaptor signatures
+                {
+                    let adaptor_secret = MaybeScalar::Valid(seckey); // arbitrary secret
+                    let adaptor_point = adaptor_secret * G;
+                    let adaptor_signature =
+                        sign_solo_adaptor(seckey, &record.message, &aux_rand, adaptor_point);
+
+                    verify_single_adaptor(
+                        pubkey,
+                        &adaptor_signature,
+                        &record.message,
+                        adaptor_point,
+                    )
+                    .expect("failed to verify valid adaptor signature");
+
+                    // Ensure the decrypted signature is valid.
+                    let valid_sig = adaptor_signature.adapt(adaptor_secret).unwrap();
+                    verify_single(pubkey, valid_sig, &record.message)
+                        .expect("failed to verify decrypted adaptor signature");
+
+                    // Ensure observers can learn the adaptor secret from published signatures.
+                    let revealed: MaybeScalar = adaptor_signature
+                        .reveal_secret(&valid_sig)
+                        .expect("decrypted signature should reveal adaptor secret");
+                    assert_eq!(revealed, adaptor_secret);
+                }
             }
 
             let verify_result = verify_single(pubkey, test_vec_signature, &record.message);
@@ -308,16 +406,12 @@ mod tests {
             };
         }
 
-        #[cfg(feature = "rand")]
-        {
-            // test batch verification
-            let (pubkeys, (messages, raw_signatures)): (Vec<_>, (Vec<_>, Vec<_>)) =
-                valid_sigs_batch
-                    .into_iter()
-                    .map(|(pk, msg, sig)| (pk, (msg, sig))) // unzip only supports tuples of length two
-                    .unzip();
+        // test batch verification
+        let (pubkeys, (messages, raw_signatures)): (Vec<_>, (Vec<_>, Vec<_>)) = valid_sigs_batch
+            .into_iter()
+            .map(|(pk, msg, sig)| (pk, (msg, sig))) // unzip only supports tuples of length two
+            .unzip();
 
-            verify_batch(&pubkeys, &messages, &raw_signatures).expect("batch verification failed");
-        }
+        verify_batch(&pubkeys, &messages, &raw_signatures).expect("batch verification failed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,27 @@ mod sig_agg;
 mod signature;
 mod signing;
 
+#[doc = include_str!("../doc/adaptor_signatures.md")]
+pub mod adaptor {
+    pub use crate::bip340::sign_solo_adaptor as sign_solo;
+    pub use crate::bip340::verify_single_adaptor as verify_single;
+    pub use crate::sig_agg::aggregate_partial_adaptor_signatures as aggregate_partial_signatures;
+    pub use crate::signature::AdaptorSignature as Signature;
+    pub use crate::signing::sign_partial_adaptor as sign_partial;
+    pub use crate::signing::verify_partial_adaptor as verify_partial;
+}
+
 pub mod errors;
 pub mod tagged_hashes;
 
 pub use binary_encoding::*;
-pub use bip340::*;
+pub use bip340::{sign_solo, verify_single};
 pub use key_agg::*;
 pub use nonces::*;
 pub use rounds::*;
-pub use sig_agg::*;
+pub use sig_agg::aggregate_partial_signatures;
 pub use signature::*;
-pub use signing::*;
+pub use signing::{compute_challenge_hash_tweak, sign_partial, verify_partial, PartialSignature};
 
 #[cfg(test)]
 pub(crate) mod testhex;
@@ -41,3 +51,6 @@ pub use secp256k1;
 
 #[cfg(feature = "k256")]
 pub use k256;
+
+#[cfg(feature = "rand")]
+pub use bip340::verify_batch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod adaptor {
     pub use crate::bip340::sign_solo_adaptor as sign_solo;
     pub use crate::bip340::verify_single_adaptor as verify_single;
     pub use crate::sig_agg::aggregate_partial_adaptor_signatures as aggregate_partial_signatures;
-    pub use crate::signature::AdaptorSignature as Signature;
+    pub use crate::signature::AdaptorSignature;
     pub use crate::signing::sign_partial_adaptor as sign_partial;
     pub use crate::signing::verify_partial_adaptor as verify_partial;
 }

--- a/src/nonces.rs
+++ b/src/nonces.rs
@@ -26,7 +26,7 @@ impl From<&[u8; 32]> for NonceSeed {
     }
 }
 
-#[cfg(feature = "rand")]
+#[cfg(any(test, feature = "rand"))]
 impl<T: rand::RngCore + rand::CryptoRng> From<&mut T> for NonceSeed {
     /// This implementation draws a [`NonceSeed`] from a mutable reference
     /// to a CSPRNG. Panics if the RNG fails to fill the seed with 32
@@ -478,7 +478,7 @@ impl SecNonce {
     ///
     /// [`SecNonce::generate`] is more secure because it combines multiple sources of
     /// entropy to compute the final nonce.
-    #[cfg(feature = "rand")]
+    #[cfg(any(test, feature = "rand"))]
     pub fn random<R>(rng: &mut R) -> SecNonce
     where
         R: rand::RngCore + rand::CryptoRng,

--- a/src/sig_agg.rs
+++ b/src/sig_agg.rs
@@ -1,9 +1,57 @@
-use secp::{MaybeScalar, Point, G};
+use secp::{MaybePoint, MaybeScalar, Point, G};
 
 use crate::errors::VerifyError;
 use crate::{
-    compute_challenge_hash_tweak, AggNonce, KeyAggContext, LiftedSignature, PartialSignature,
+    compute_challenge_hash_tweak, AdaptorSignature, AggNonce, KeyAggContext, LiftedSignature,
+    PartialSignature,
 };
+
+/// Aggregate a collection of partial adaptor signatures together into a final
+/// signature on a given `message`, under the aggregated public key in `key_agg_ctx`.
+///
+/// The resulting signature will not be valid unless adapted with the discrete log
+/// of the `adaptor_point`.
+///
+/// Returns an error if the resulting signature would not be valid.
+pub fn aggregate_partial_adaptor_signatures<S: Into<PartialSignature>>(
+    key_agg_ctx: &KeyAggContext,
+    aggregated_nonce: &AggNonce,
+    adaptor_point: impl Into<MaybePoint>,
+    partial_signatures: impl IntoIterator<Item = S>,
+    message: impl AsRef<[u8]>,
+) -> Result<AdaptorSignature, VerifyError> {
+    let adaptor_point: MaybePoint = adaptor_point.into();
+    let aggregated_pubkey = key_agg_ctx.pubkey;
+
+    let b: MaybeScalar = aggregated_nonce.nonce_coefficient(aggregated_pubkey, &message);
+    let final_nonce: Point = aggregated_nonce.final_nonce(b);
+    let adapted_nonce = final_nonce + adaptor_point;
+    let nonce_x_bytes = adapted_nonce.serialize_xonly();
+    let e: MaybeScalar = compute_challenge_hash_tweak(&nonce_x_bytes, &aggregated_pubkey, &message);
+
+    let aggregated_signature = partial_signatures
+        .into_iter()
+        .map(|sig| sig.into())
+        .sum::<PartialSignature>()
+        + (e * key_agg_ctx.tweak_acc).negate_if(aggregated_pubkey.parity());
+
+    let effective_nonce = if adapted_nonce.has_even_y() {
+        final_nonce
+    } else {
+        -final_nonce
+    };
+
+    // Ensure the signature will verify as valid.
+    if aggregated_signature * G != effective_nonce + e * aggregated_pubkey.to_even_y() {
+        return Err(VerifyError::BadSignature);
+    }
+
+    let adaptor_sig = AdaptorSignature {
+        R: MaybePoint::Valid(final_nonce),
+        s: aggregated_signature,
+    };
+    Ok(adaptor_sig)
+}
 
 /// Aggregate a collection of partial signatures together into a final
 /// signature on a given `message`, valid under the aggregated public
@@ -20,38 +68,25 @@ where
     S: Into<PartialSignature>,
     T: From<LiftedSignature>,
 {
-    let aggregated_pubkey = key_agg_ctx.pubkey;
+    let sig = aggregate_partial_adaptor_signatures(
+        key_agg_ctx,
+        aggregated_nonce,
+        MaybePoint::Infinity,
+        partial_signatures,
+        message,
+    )?
+    .adapt(MaybeScalar::Zero)
+    .map(T::from)
+    .expect("aggregating with empty adaptor should never result in an adaptor failure");
 
-    let b: MaybeScalar = aggregated_nonce.nonce_coefficient(aggregated_pubkey, &message);
-    let final_nonce = aggregated_nonce.final_nonce::<Point>(b).to_even_y();
-    let final_nonce_x_bytes = final_nonce.serialize_xonly();
-
-    let e: MaybeScalar =
-        compute_challenge_hash_tweak(&final_nonce_x_bytes, &aggregated_pubkey, &message);
-
-    let aggregated_signature = partial_signatures
-        .into_iter()
-        .map(|sig| sig.into())
-        .sum::<PartialSignature>()
-        + (e * key_agg_ctx.tweak_acc).negate_if(aggregated_pubkey.parity());
-
-    // Ensure the signature will verify as valid.
-    if aggregated_signature * G != final_nonce + e * aggregated_pubkey.to_even_y() {
-        return Err(VerifyError::BadSignature);
-    }
-
-    let lifted_sig = LiftedSignature {
-        R: final_nonce,
-        s: aggregated_signature,
-    };
-    Ok(T::from(lifted_sig))
+    Ok(sig)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testhex;
-    use crate::{verify_single, CompactSignature, PubNonce};
+    use crate::{verify_single, CompactSignature, PubNonce, SecNonce};
 
     use secp::{Point, Scalar};
 
@@ -153,6 +188,93 @@ mod tests {
                     aggregated_signature
                 ),
             );
+        }
+    }
+
+    #[test]
+    fn test_adaptor_signature_aggregation() {
+        const ITERATIONS: usize = 10;
+
+        for _ in 0..ITERATIONS {
+            let seckeys = [
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+            ];
+
+            let pubkeys = [
+                seckeys[0].base_point_mul(),
+                seckeys[1].base_point_mul(),
+                seckeys[2].base_point_mul(),
+            ];
+
+            let key_agg_ctx = KeyAggContext::new(pubkeys).unwrap();
+
+            let message = b"danger, will robinson!";
+
+            let secnonces = [
+                SecNonce::random(&mut rand::thread_rng()),
+                SecNonce::random(&mut rand::thread_rng()),
+                SecNonce::random(&mut rand::thread_rng()),
+            ];
+
+            let pubnonces = [
+                secnonces[0].public_nonce(),
+                secnonces[1].public_nonce(),
+                secnonces[2].public_nonce(),
+            ];
+
+            let aggnonce = AggNonce::sum(&pubnonces);
+
+            let adaptor_secret = Scalar::random(&mut rand::thread_rng());
+            let adaptor_point = adaptor_secret.base_point_mul();
+
+            let partial_signatures: Vec<PartialSignature> = seckeys
+                .into_iter()
+                .zip(secnonces)
+                .map(|(seckey, secnonce)| {
+                    crate::adaptor::sign_partial(
+                        &key_agg_ctx,
+                        seckey,
+                        secnonce,
+                        &aggnonce,
+                        adaptor_point,
+                        &message,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .expect("failed to create partial adaptor signatures");
+
+            let adaptor_signature: AdaptorSignature = crate::adaptor::aggregate_partial_signatures(
+                &key_agg_ctx,
+                &aggnonce,
+                adaptor_point,
+                partial_signatures.iter().copied(),
+                &message,
+            )
+            .expect("failed to aggregate partial adaptor signatures");
+
+            crate::adaptor::verify_single(
+                key_agg_ctx.aggregated_pubkey::<Point>(),
+                &adaptor_signature,
+                &message,
+                adaptor_point,
+            )
+            .expect("invalid aggregated adaptor signature");
+
+            let valid_signature = adaptor_signature.adapt(adaptor_secret).unwrap();
+            verify_single(
+                key_agg_ctx.aggregated_pubkey::<Point>(),
+                valid_signature,
+                &message,
+            )
+            .expect("invalid decrypted adaptor signature");
+
+            let revealed: MaybeScalar = adaptor_signature
+                .reveal_secret(&valid_signature)
+                .expect("should compute adaptor secret from decrypted signature");
+
+            assert_eq!(revealed, MaybeScalar::Valid(adaptor_secret));
         }
     }
 }

--- a/src/sig_agg.rs
+++ b/src/sig_agg.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 
 /// Aggregate a collection of partial adaptor signatures together into a final
-/// signature on a given `message`, under the aggregated public key in `key_agg_ctx`.
+/// adaptor signature on a given `message`, under the aggregated public key in
+/// `key_agg_ctx`.
 ///
 /// The resulting signature will not be valid unless adapted with the discrete log
 /// of the `adaptor_point`.

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,4 @@
-use secp::{MaybeScalar, Point};
+use secp::{MaybePoint, MaybeScalar, Point, Scalar, G};
 
 use crate::errors::DecodeError;
 use crate::BinaryEncoding;
@@ -100,6 +100,18 @@ impl LiftedSignature {
         CompactSignature::new(self.R, self.s)
     }
 
+    /// Encrypts an existing valid signature by subtracting a given adaptor secret.
+    pub fn encrypt(&self, adaptor_secret: impl Into<Scalar>) -> AdaptorSignature {
+        AdaptorSignature::new(self.R, self.s).encrypt(adaptor_secret)
+
+        // let adaptor_secret: Scalar = adaptor_secret.into();
+
+        // AdaptorSignature {
+        //     R: self.R - adaptor_secret * G,
+        //     s: self.s - adaptor_secret,
+        // }
+    }
+
     /// Unzip this signature pair into a tuple of any two types
     /// which convert from [`secp::Point`] and [`secp::MaybeScalar`].
     ///
@@ -126,6 +138,118 @@ impl LiftedSignature {
     pub fn unzip<P, S>(&self) -> (P, S)
     where
         P: From<Point>,
+        S: From<MaybeScalar>,
+    {
+        (P::from(self.R), S::from(self.s))
+    }
+}
+
+/// A representation of a Schnorr adaptor signature point+scalar pair `(R', s')`.
+///
+/// Differs from [`LiftedSignature`] in that an `AdaptorSignature`
+/// is explicitly modified with by specific scalar offset, so that
+/// only by learning the adaptor secret can its holder convert it
+/// into a valid BIP340 signature.
+///
+/// Since `AdaptorSignature` is not meant for on-chain consensus, the nonce
+/// point `R` can have either even or odd parity, and so `AdaptorSignature`
+/// is encoded as a 65 byte array which includes the compressed `R` point.
+///
+/// To learn more about adaptor signatures and how to use them, see the docs
+/// in [the adaptor module][crate::adaptor].
+///
+/// To construct an `AdaptorSignature`, use [`LiftedSignature::encrypt`],
+/// [`adaptor::sign_solo`][crate::adaptor::sign_solo], or
+/// [`adaptor::aggregate_partial_signatures`][crate::adaptor::aggregate_partial_signatures].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdaptorSignature {
+    pub(crate) R: MaybePoint,
+    pub(crate) s: MaybeScalar,
+}
+
+impl AdaptorSignature {
+    /// Constructs a new adaptor signature from a nonce and scalar pair.
+    ///
+    /// Accepts any types which convert to a [`secp::MaybePoint`] and
+    /// [`secp::MaybeScalar`].
+    pub fn new(R: impl Into<MaybePoint>, s: impl Into<MaybeScalar>) -> AdaptorSignature {
+        AdaptorSignature {
+            R: R.into(),
+            s: s.into(),
+        }
+    }
+
+    /// Adapts the signature into a lifted signature with a given adaptor secret.
+    ///
+    /// Returns `None` if the nonce resulting from adding the adaptor point is the
+    /// point at infinity.
+    ///
+    /// The resulting signature is not guaranteed to be valid unless the
+    ///`AdaptorSignature` was already verified with
+    /// [`adaptor::verify_single`][crate::adaptor::verify_single].
+    /// If not, make sure to verify the resulting lifted signature
+    /// using [`verify_single`][crate::verify_single].
+    pub fn adapt<T: From<LiftedSignature>>(
+        &self,
+        adaptor_secret: impl Into<MaybeScalar>,
+    ) -> Option<T> {
+        let adaptor_secret: MaybeScalar = adaptor_secret.into();
+        let adapted_nonce = (self.R + adaptor_secret * G).into_option()?;
+        let adapted_sig = self.s + adaptor_secret.negate_if(adapted_nonce.parity());
+        Some(T::from(LiftedSignature::new(adapted_nonce, adapted_sig)))
+    }
+
+    /// Encrypts an existing adaptor signature again, by subtracting another adaptor secret.
+    pub fn encrypt(&self, adaptor_secret: impl Into<Scalar>) -> AdaptorSignature {
+        let adaptor_secret: Scalar = adaptor_secret.into();
+        AdaptorSignature {
+            R: self.R - adaptor_secret * G,
+            s: self.s - adaptor_secret,
+        }
+    }
+
+    /// Using a decrypted signature `final_sig`, this method computes the
+    /// adaptor secret  used to encrypt this signature.
+    ///
+    /// Returns `None` if `final_sig` is not related to this adaptor signature.
+    pub fn reveal_secret<S>(&self, final_sig: &LiftedSignature) -> Option<S>
+    where
+        S: From<MaybeScalar>,
+    {
+        let t = final_sig.s - self.s;
+        let T = t * G;
+
+        if T == final_sig.R - self.R {
+            Some(S::from(t))
+        } else if T == final_sig.R + self.R {
+            Some(S::from(-t))
+        } else {
+            None
+        }
+    }
+
+    /// Unzip this signature pair into a tuple of any two types
+    /// which convert from [`secp::MaybePoint`] and [`secp::MaybeScalar`].
+    ///
+    /// ```
+    /// // This allows us to use `R` as a variable name.
+    /// #![allow(non_snake_case)]
+    ///
+    /// let signature = "02c1de0db357c5d780c69624d0ab266a3b6866301adc85b66cc9fce26d2a60b72c\
+    ///                  659c15ed9bc81df681e1e0607cf44cc08e77396f74359de1e6e6ff365ca94dae"
+    ///     .parse::<musig2::AdaptorSignature>()
+    ///     .unwrap();
+    ///
+    /// let (R, s): ([u8; 33], [u8; 32]) = signature.unzip();
+    /// let (R, s): (secp::MaybePoint, secp::MaybeScalar) = signature.unzip();
+    /// # #[cfg(feature = "k256")]
+    /// # {
+    /// let (R, s): (k256::AffinePoint, k256::Scalar) = signature.unzip();
+    /// # }
+    /// ```
+    pub fn unzip<P, S>(&self) -> (P, S)
+    where
+        P: From<MaybePoint>,
         S: From<MaybeScalar>,
     {
         (P::from(self.R), S::from(self.s))
@@ -178,11 +302,37 @@ mod encodings {
         }
     }
 
+    impl BinaryEncoding for AdaptorSignature {
+        type Serialized = [u8; 65];
+
+        /// Serializes the signature to a compressed 65-byte encoding,
+        /// including the compressed `R` point and the serialized `s` scalar.
+        fn to_bytes(&self) -> Self::Serialized {
+            let mut serialized = [0u8; 65];
+            serialized[..33].clone_from_slice(&self.R.serialize());
+            serialized[33..].clone_from_slice(&self.s.serialize());
+            serialized
+        }
+
+        /// Deserialize an adaptor signature from a byte slice. This
+        /// slice must be exactly 65 bytes long.
+        fn from_bytes(signature_bytes: &[u8]) -> Result<Self, DecodeError<Self>> {
+            if signature_bytes.len() != 65 {
+                return Err(DecodeError::bad_length(signature_bytes.len()));
+            }
+            let R = MaybePoint::try_from(&signature_bytes[..33])?;
+            let s = MaybeScalar::try_from(&signature_bytes[33..])?;
+            Ok(AdaptorSignature { R, s })
+        }
+    }
+
     impl_encoding_traits!(CompactSignature, SCHNORR_SIGNATURE_SIZE);
     impl_encoding_traits!(LiftedSignature, SCHNORR_SIGNATURE_SIZE);
+    impl_encoding_traits!(AdaptorSignature, 65);
 
     impl_hex_display!(CompactSignature);
     impl_hex_display!(LiftedSignature);
+    impl_hex_display!(AdaptorSignature);
 }
 
 mod internal_conversions {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -103,13 +103,6 @@ impl LiftedSignature {
     /// Encrypts an existing valid signature by subtracting a given adaptor secret.
     pub fn encrypt(&self, adaptor_secret: impl Into<Scalar>) -> AdaptorSignature {
         AdaptorSignature::new(self.R, self.s).encrypt(adaptor_secret)
-
-        // let adaptor_secret: Scalar = adaptor_secret.into();
-
-        // AdaptorSignature {
-        //     R: self.R - adaptor_secret * G,
-        //     s: self.s - adaptor_secret,
-        // }
     }
 
     /// Unzip this signature pair into a tuple of any two types
@@ -146,8 +139,8 @@ impl LiftedSignature {
 
 /// A representation of a Schnorr adaptor signature point+scalar pair `(R', s')`.
 ///
-/// Differs from [`LiftedSignature`] in that an `AdaptorSignature`
-/// is explicitly modified with by specific scalar offset, so that
+/// Differs from [`LiftedSignature`] in that an `AdaptorSignature` is explicitly
+/// modified with by specific scalar offset called the _adaptor secret,_ so that
 /// only by learning the adaptor secret can its holder convert it
 /// into a valid BIP340 signature.
 ///
@@ -209,7 +202,7 @@ impl AdaptorSignature {
     }
 
     /// Using a decrypted signature `final_sig`, this method computes the
-    /// adaptor secret  used to encrypt this signature.
+    /// adaptor secret used to encrypt this signature.
     ///
     /// Returns `None` if `final_sig` is not related to this adaptor signature.
     pub fn reveal_secret<S>(&self, final_sig: &LiftedSignature) -> Option<S>


### PR DESCRIPTION
Adds support for adaptor signatures, both for MuSig2 and for BIP340 solo-signing.

