### PR TITLE
Bump `secp256k1` to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ hmac = { version = "0.12.1", default-features = false, features = [] }
 k256 = { version = "0.13.1", default-features = false, optional = true }
 once_cell = { version = "1.18.0", default-features = false }
 rand = { version = "0.8.5", optional = true, default-features = false, features = ["std_rng"] }
-secp = { version = "0.2.0", default-features = false }
+secp = { version = "0.3", default-features = false }
 secp256k1 = { version = "0.29", optional = true, default-features = false }
 serde = { version = "1.0.188", default-features = false, optional = true }
 serdect = { version = "0.2.0", default-features = false, optional = true, features = ["alloc"] }
@@ -29,7 +29,7 @@ serde_json = "1.0.107"
 csv = "1.3.0"
 serdect = "0.2.0"
 rand = "0.8.5"
-secp = { version = "0.2.0", default-features = false, features = ["serde", "rand", "secp256k1-invert"]  }
+secp = { version = "0.3", default-features = false, features = ["serde", "rand", "secp256k1-invert"]  }
 
 [features]
 default = ["secp256k1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ k256 = { version = "0.13.1", default-features = false, optional = true }
 once_cell = { version = "1.18.0", default-features = false }
 rand = { version = "0.8.5", optional = true, default-features = false, features = ["std_rng"] }
 secp = { version = "0.2.0", default-features = false }
-secp256k1 = { version = "0.28.0", optional = true, default-features = false }
+secp256k1 = { version = "0.29", optional = true, default-features = false }
 serde = { version = "1.0.188", default-features = false, optional = true }
 serdect = { version = "0.2.0", default-features = false, optional = true, features = ["alloc"] }
 sha2 = { version = "0.10.8", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,26 @@ check: check-default check-mixed check-secp256k1 check-k256
 
 # Checks the source code with default features enabled.
 check-default:
-	cargo check
+	cargo clippy
 
 # Checks the source code with all features enabled.
 check-mixed:
-	cargo check --all-features
-	cargo check --all-features --tests
+	cargo clippy --all-features
+	cargo clippy --all-features --tests
 
 # Checks the source code with variations of libsecp256k1 feature sets.
 check-secp256k1:
-	cargo check --no-default-features --features secp256k1
-	cargo check --no-default-features --features secp256k1,serde
-	cargo check --no-default-features --features secp256k1,serde,rand
-	cargo check --no-default-features --features secp256k1,serde,rand --tests
+	cargo clippy --no-default-features --features secp256k1
+	cargo clippy --no-default-features --features secp256k1,serde
+	cargo clippy --no-default-features --features secp256k1,serde,rand
+	cargo clippy --no-default-features --features secp256k1,serde,rand --tests
 
 # Checks the source code with variations of pure-rust feature sets.
 check-k256:
-	cargo check --no-default-features --features k256
-	cargo check --no-default-features --features k256,serde
-	cargo check --no-default-features --features k256,serde,rand
-	cargo check --no-default-features --features k256,serde,rand --tests
+	cargo clippy --no-default-features --features k256
+	cargo clippy --no-default-features --features k256,serde
+	cargo clippy --no-default-features --features k256,serde,rand
+	cargo clippy --no-default-features --features k256,serde,rand --tests
 
 
 test: test-default test-mixed test-secp256k1 test-k256

--- a/doc/adaptor_signatures.md
+++ b/doc/adaptor_signatures.md
@@ -6,7 +6,7 @@ Adaptor signatures allow signers to create Schnorr signatures which can be verif
 
 ## MuSig Example
 
-Here we demonstrate a group of MuSig2 signers adaptor-signing the same message. The final signature which the group constructs is an [`AdaptorSignature`][crate::AdaptorSignature], which they cannot use until it has been decrypted (AKA 'adapted') by the correct adaptor secret (a scalar).
+Here we demonstrate a group of MuSig2 signers adaptor-signing the same message. The final signature which the group constructs is an [`AdaptorSignature`], which they cannot use until it has been decrypted (AKA 'adapted') by the correct adaptor secret (a scalar).
 
 ```rust
 use secp::{MaybeScalar, Point, Scalar};

--- a/src/tagged_hashes.rs
+++ b/src/tagged_hashes.rs
@@ -39,9 +39,7 @@ use sha2::Sha256;
 use sha2::Digest as _;
 
 fn with_tag_hash_prefix(tag_hash: [u8; 32]) -> Sha256 {
-    Sha256::new()
-        .chain_update(&tag_hash)
-        .chain_update(&tag_hash)
+    Sha256::new().chain_update(tag_hash).chain_update(tag_hash)
 }
 
 /// sha256(b"KeyAgg list")

--- a/src/testhex.rs
+++ b/src/testhex.rs
@@ -28,7 +28,7 @@ impl<const SIZE: usize> TryFromBytes for [u8; SIZE] {
         }
 
         let mut array = [0; SIZE];
-        array[..].clone_from_slice(&bytes);
+        array[..].clone_from_slice(bytes);
         Ok(array)
     }
 }


### PR DESCRIPTION
It would be really great if we could have a new `musig2` release with `0.0.12` that supports `rust-bitcoin` `0.32` that uses `secp256k1` `0.29`.
All test passes locally.
I took the liberty of also adding some clippy lint fixes in a separate commit.


Thank you for the awesome work!