### PR TITLE
ci: GitHub Actions and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+  workflow_dispatch: null
+
+jobs:
+  check:
+    name: "Check the code compiles"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Check
+        run: cargo check
+
+  fmt:
+    name: "Cargo fmt"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: rustfmt
+        run: cargo fmt --all --check
+
+  clippy:
+    name: "Clippy"
+    needs: [check, fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Clippy default
+        run: make check-default
+      - name: Clippy all features
+        run: make check-mixed
+      - name: Clippy libsecp feature set
+        run: make check-secp256k1
+      - name: Clippy pure-rust feature set
+        run: make check-k256
+
+  docs:
+    needs: [check, fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
+        run: cargo doc --all-features --no-deps
+
+  test:
+    needs: [check, fmt, clippy]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+        recipe:
+          - "test-default"
+          - "test-mixed"
+          - "test-secp256k1"
+          - "test-k256"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Run tests
+        run: make ${{ matrix.recipe }}

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,26 @@ check: check-default check-mixed check-secp256k1 check-k256
 
 # Checks the source code with default features enabled.
 check-default:
-	cargo clippy
+	cargo clippy -- -D warnings
 
 # Checks the source code with all features enabled.
 check-mixed:
-	cargo clippy --all-features
-	cargo clippy --all-features --tests
+	cargo clippy --all-features -- -D warnings
+	cargo clippy --all-features --tests -- -D warnings
 
 # Checks the source code with variations of libsecp256k1 feature sets.
 check-secp256k1:
-	cargo clippy --no-default-features --features secp256k1
-	cargo clippy --no-default-features --features secp256k1,serde
-	cargo clippy --no-default-features --features secp256k1,serde,rand
-	cargo clippy --no-default-features --features secp256k1,serde,rand --tests
+	cargo clippy --no-default-features --features secp256k1 -- -D warnings
+	cargo clippy --no-default-features --features secp256k1,serde -- -D warnings
+	cargo clippy --no-default-features --features secp256k1,serde,rand -- -D warnings
+	cargo clippy --no-default-features --features secp256k1,serde,rand --tests -- -D warnings
 
 # Checks the source code with variations of pure-rust feature sets.
 check-k256:
-	cargo clippy --no-default-features --features k256
-	cargo clippy --no-default-features --features k256,serde
-	cargo clippy --no-default-features --features k256,serde,rand
-	cargo clippy --no-default-features --features k256,serde,rand --tests
+	cargo clippy --no-default-features --features k256 -- -D warnings
+	cargo clippy --no-default-features --features k256,serde -- -D warnings
+	cargo clippy --no-default-features --features k256,serde,rand -- -D warnings
+	cargo clippy --no-default-features --features k256,serde,rand --tests -- -D warnings
 
 
 test: test-default test-mixed test-secp256k1 test-k256


### PR DESCRIPTION
Closes #6.

I've tested them in my forked repo: https://github.com/storopoli/musig2/pull/1/checks

Here's how the tests look like. Everything that don't have different `needs` is trivially parallelizable and hence it runs in parallel:
![image](https://github.com/user-attachments/assets/abf71d65-2da9-4342-8f38-ab26b2072b4f)
