### PR TITLE
Document partial signature forgeability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you're not already familiar with MuSig2, the process of cooperative signing r
 1. All signers share their public keys with one-another. The group computes an _aggregated public key_ which they collectively control.
 2. In the **first signing round,** signers generate and share _nonces_ (random numbers) with one-another. These nonces have both secret and public versions. Only the public nonce (AKA `PubNonce`) should be shared, while the corresponding secret nonce (AKA `SecNonce`) must be kept secret.
 3. Once every signer has received the public nonces of every other signer, each signer makes a _partial signature_ for a message using their secret key and secret nonce.
-4. In the **second signing round,** signers share their partial signatures with one-another. Partial signatures can be verified to place blame on misbehaving signers.
+4. In the **second signing round,** signers share their partial signatures with one-another. Partial signatures can be verified to place blame on misbehaving signers (but are not themselves unforgeable).
 5. A valid set of partial signatures can be aggregated into a final signature, which is just a normal [Schnorr signature](https://en.wikipedia.org/wiki/Schnorr_signature), valid under the aggregated public key.
 
 ## Choice of Backbone

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -135,6 +135,9 @@ pub fn sign_partial<T: From<PartialSignature>>(
 /// to be valid once it is adapted with the discrete log (secret key)
 /// of `adaptor_point`.
 ///
+/// Note that partial signatures are _not_ unforgeable!
+/// Validity of a partial signature should not be relied on for this property.
+///
 /// Returns an error if the given public key doesn't belong to the
 /// `key_agg_ctx`, or if the signature is invalid.
 pub fn verify_partial_adaptor(
@@ -186,6 +189,9 @@ pub fn verify_partial_adaptor(
 /// If `verify_partial` succeeds for every signature in
 /// a signing session, the resulting aggregated signature is guaranteed
 /// to be valid.
+///
+/// Note that partial signatures are _not_ unforgeable!
+/// Validity of a partial signature should not be relied on for this property.
 ///
 /// This function is effectively the same as invoking [`verify_partial_adaptor`]
 /// but passing [`MaybePoint::Infinity`] as the adaptor point.

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -137,6 +137,7 @@ pub fn sign_partial<T: From<PartialSignature>>(
 ///
 /// Note that partial signatures are _not_ unforgeable!
 /// Validity of a partial signature should not be relied on for this property.
+/// See <https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b> for details.
 ///
 /// Returns an error if the given public key doesn't belong to the
 /// `key_agg_ctx`, or if the signature is invalid.
@@ -192,6 +193,7 @@ pub fn verify_partial_adaptor(
 ///
 /// Note that partial signatures are _not_ unforgeable!
 /// Validity of a partial signature should not be relied on for this property.
+/// See <https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b> for details.
 ///
 /// This function is effectively the same as invoking [`verify_partial_adaptor`]
 /// but passing [`MaybePoint::Infinity`] as the adaptor point.


### PR DESCRIPTION
As noted in a footnote of section 4.2 of the [MuSig2 preprint](https://eprint.iacr.org/archive/2020/1261/20231020:081535), it is possible for an adversary to forge the partial signature of an honest signer under certain conditions. This means that while validity of _all_ partial signatures from a signing operation necessarily implies validity of the corresponding aggregated signature, validity of any particular partial signature cannot alone be relied on for any use cases requiring its unforgeability.

This is a subtle but important point that was not included in the documentation. This PR updates accordingly.