### PR TITLE
Constant Size Values for Nonces and Partial Signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,10 @@ pub use nonces::*;
 pub use rounds::*;
 pub use sig_agg::aggregate_partial_signatures;
 pub use signature::*;
-pub use signing::{compute_challenge_hash_tweak, sign_partial, verify_partial, PartialSignature};
+pub use signing::{
+    compute_challenge_hash_tweak, sign_partial, verify_partial, PartialSignature,
+    PARTIAL_SIGNATURE_SIZE,
+};
 
 #[cfg(test)]
 pub(crate) mod testhex;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -260,8 +260,8 @@ mod encodings {
         /// serialized `s` scalar.
         fn to_bytes(&self) -> Self::Serialized {
             let mut serialized = [0u8; SCHNORR_SIGNATURE_SIZE];
-            serialized[..32].clone_from_slice(&self.rx);
-            serialized[32..].clone_from_slice(&self.s.serialize());
+            serialized[..SCHNORR_SIGNATURE_SIZE / 2].clone_from_slice(&self.rx);
+            serialized[SCHNORR_SIGNATURE_SIZE / 2..].clone_from_slice(&self.s.serialize());
             serialized
         }
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -5,6 +5,9 @@ use secp::{MaybePoint, MaybeScalar, Point, Scalar, G};
 
 use sha2::Digest as _;
 
+/// The size of a serialized partial signature in bytes.
+pub const PARTIAL_SIGNATURE_SIZE: usize = 32;
+
 /// Partial signatures are just scalars in the range `[0, n)`.
 ///
 /// See the documentation of [`secp::MaybeScalar`] for the


### PR DESCRIPTION
Adds constants for the size in bytes of public and secret nonces; and partial signatures in the MuSig2 protocol.

Makes it easier for downstream users to not have to rely on magic numbers when serializing to/from bytes these types.